### PR TITLE
Fix for antl4 import error in Python>=3.12

### DIFF
--- a/zemberek/morphology/analysis/tr/turkish_numbers.py
+++ b/zemberek/morphology/analysis/tr/turkish_numbers.py
@@ -47,7 +47,7 @@ class TurkishNumbers:
         sb: List[str] = []
 
         i = 0
-        while i < len(inp) and inp[i] == 0:
+        while i < len(inp) and inp[i] == "0":
             sb.append("sıfır")
             i += 1
 

--- a/zemberek/tokenization/__init__.py
+++ b/zemberek/tokenization/__init__.py
@@ -1,2 +1,12 @@
+import sys
+
+# antlr4 imports typing.io to use TextIO; typing.io was removed in Python 3.12
+# Therefore a compatibility shim is needed
+if sys.version_info >= (3, 12):
+    import typing
+
+    typing.io = typing
+    sys.modules.setdefault("typing.io", typing)
+
 from .turkish_tokenizer import TurkishTokenizer
 from .turkish_sentence_extractor import TurkishSentenceExtractor


### PR DESCRIPTION
Antlr4 imports typing.io to use TextIO which already exists in the typing module. typing.io was removed in python 3.12 and this caused zemberek-python to not work on modern python runtimes. This pull request allows zemberek-python to import antlr4 in modern python without issues.

It also fixes a small bug where 0012 would not be converted to "sıfır sıfır on iki"